### PR TITLE
Modifications and additions to the script

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@ This script is a utility to extract libraries such as binaries, services and oth
 
 > [!CAUTION]
 > The utility only interacts passively between the stock ROM folders the files requested in the script. Therefore, there are not enough changes to work magic and create a correct Device Tree with the files extrated.
+> >
 > The files are as they are, and what will make the difference in having a correct Device Tree is how the user makes his own modifications based on his own device. In addition, it is important that the user reviews the result (output folders) and the stock ROM folders to check and see if more files are still needed.
+> >
 > In this context, learning and having knowledge[^¹] for the changes, as well as where the information is and where to place it is the user's sole responsibility.
 
 ---
@@ -13,7 +15,7 @@ This script is a utility to extract libraries such as binaries, services and oth
 
 - Extracts **keymaster**, **gatekeeper**, **keymint** binaries and libraries files from the Firmware folder.
 - Extracts binaries files from `vendor/bin/hw` related to `keymaster`, `gatekeeper`, or `keymint`.
-- Extracts binaries files from `vendor/bin` related to `mcRegistry`, `teei_daemon`, or `teed`.
+- Extracts service files from `vendor/bin` related to `mcRegistry`, `teei_daemon`, or `teed`.
 - Extracts files from the following paths if they exist:
   - `vendor/app/mcRegistry`
   - `vendor/thh/ta`
@@ -34,7 +36,7 @@ This script is a utility to extract libraries such as binaries, services and oth
   - `vendor/firmware`
   - `vendor/etc/vintf`
   - `vendor/etc/vintf/manifest`
-- Cleans up **empty directories** after extraction, including automatically checking if `system_ext` is empty and deleting it.
+- Cleans up **empty directories** after extraction, including automatically checking if `system_ext` and/or `vendor/app` is empty and deleting it.
 
 ---
 
@@ -64,19 +66,16 @@ Before using this script, ensure:
 ### Unpacked stock ROM folders from firmware.img
 1. Copy stock ROM folders to `extract_android_crypto_blobs/Firmware` folder.
    Example: `/Firmware/vendor` & `/Firmware/system` & `/Firmware/system_ext`
-   Dont't worries if you stock ROM not have `/system_ext`.
-   Usually the stock ROM system.img file is unpacked like this: `system/system/`. Note that we want the second part of `system` and therefore indicated like system/**system/**.
+   - Dont't worries if you stock ROM not have `/system_ext`.
+   - Usually the stock ROM system.img file is unpacked like this: `system/system/`. Note that we want the second part of `system` and therefore indicated like system/**system/**.
 
-   
-<details><summary>Click to open</summary>
-<p>
+   >
+   <details><summary>Click to open</summary>
+   <p>
 
-## copy picture od FileManager extract_android_crypto_blobs/Firmware
-
-
-</p>
-</details>
-
+   ![stock_ROM](https://github.com/user-attachments/assets/00cb6c62-96a0-46e4-ac24-8b3bc14e2b19)
+   </p>
+   </details>
 
 ### Run the script
 2. Run[^³] the script according to the extracted extract_android_crypto_blobs folder or the folder that you created:
@@ -84,22 +83,9 @@ Before using this script, ensure:
    ./extract_crypto_blobs.sh
    ```
 
-<details><summary>Click to open</summary>
-<p>
-
-## copy picture od FileManager extract_android_crypto_blobs
-
-
-</p>
-</details>
-
 
 [^¹]: If you want to learn more, visit [Copying firmware files to the Device Tree - Mediatek](https://gist.github.com/lopestom/c4a2648958db5c3db03d32033a3583cd)
-[^²]: This script **already has permission**. But if you have any doubts then you can check the script with:
-   ```bash
-   chmod +x extract_crypto_blobs.sh
-   ```
-
+[^²]: This script **already has permission**. But if you have any doubts then you can check the script with `chmod +x extract_crypto_blobs.sh`
 [^³]: Use whatever Terminal emulator you want/prefer. You can type directly into the Terminal or double-click on the sh file.
 
 ---
@@ -132,6 +118,7 @@ After extraction, the sorted files are automatically copied into the following a
 1. **Automatic Cleanup**:
    - Deletes empty directories after extraction.
    - Cleans `system_ext` only if it's completely empty.
+   - Cleans `vendor/app` only if it's completely empty.
 
 2. **Binaries Search**:
    - The script searches for `keymaster`, `gatekeeper` and `keymint` binaries/libraries files automatically.
@@ -141,9 +128,9 @@ After extraction, the sorted files are automatically copied into the following a
      <details><summary>Click to open</summary>
      <p>
 
-     ## copy pictureS od FileManager extract_android_crypto_blobs
-
-
+       ![A](https://github.com/user-attachments/assets/58a2da30-0fcd-407d-9e80-892732c092fe)
+       ![B](https://github.com/user-attachments/assets/760ce1b0-4f9b-4bea-90b6-281234d61218)
+       ![C](https://github.com/user-attachments/assets/1fd9a4b1-d246-4c77-bf6d-7a4a861067e9)
      </p>
      </details>
 
@@ -161,11 +148,12 @@ Visualization and Explanation of script steps
 Step | happening |   | Step | happening
 | ---: | :--- | :---: | ---: | :---
 1-| Run the script |  | 6- | Debugging with encryption/decryption mode visualization
-2-| Alert message so you don't forget |  | 7- | Script starts searching to copy
-3-| Confirm your choice |  | 8- | Script searching and copying the files
-4-| Answer the question |  | 9- | Skipping the folders&files not finded
-5-| The script is starting |  | 10- | Script completion notice
+2-| Alert message so you don't forget |  | 7-| Script starts searching to copy
+3-| Confirm your choice |  | 8-| Script searching and copying the files
+4-| Answer the question |  | 9-| Skipping the folders&files not finded
+5-| The script is starting |  | 10-| Script completion advise
 
+   ![ExACriB](https://github.com/user-attachments/assets/680b0e77-1d2f-48db-add7-c558f06824db)
 
 </p>
 </details>
@@ -174,10 +162,13 @@ Step | happening |   | Step | happening
 <details><summary>If you **NOT** copied stock ROM to Firmware folder - Click to open</summary>
 <p>
 
-Step | happening |
-| ---: | :--- |
-11-| Simple message to continue script after required action
+Step | happening |   | Step | happening
+| ---: | :--- | :---: | ---: | :---
+1-| Run the script |  | 4-| Answer the question |
+2-| Alert message so you don't forget |  | 11-| Simple message to continue script after required action
+3-| Confirm your choice |  |   |  
 
+![11](https://github.com/user-attachments/assets/842b091c-365a-4475-b2a7-d301844ec109)
 
 </p>
 </details>

--- a/README.md
+++ b/README.md
@@ -1,26 +1,39 @@
-
 # Crypto Blob Extractor Tool
 
-This script is a utility for extracting specific system libraries, binaries, and other essential components related to `keymaster`, `gatekeeper`, and `keymint`. It also includes additional extraction for specific directories like `mcRegistry` and `thh/ta`. The tool is intended for ROM extraction tasks such as preparing extracted files for custom recovery (TWRP, LineageOS, etc.) or other modding purposes.
+This script is a utility to extract libraries such as binaries, services and other essential components & files related to `keymaster`, `gatekeeper` and `keymint` specifically from /system, /vendor and /system_ext (if present). It also includes additional extraction for specific directories such as `app/mcRegistry`, `thh/ta` and `app/t6`. The tool is intended for firmware/ROM extraction tasks such as preparing and copying extracted files to the device tree of a custom recovery (TWRP, LineageOS, etc.) or other modding purposes. The goal is to be simple and easy, have greater agility.
+
+> [!CAUTION]
+> The utility only interacts passively between the stock ROM folders the files requested in the script. Therefore, there are not enough changes to work magic and create a correct Device Tree with the files extrated.
+> The files are as they are, and what will make the difference in having a correct Device Tree is how the user makes his own modifications based on his own device. In addition, it is important that the user reviews the result (output folders) and the stock ROM folders to check and see if more files are still needed.
+> In this context, learning and having knowledge[^¹] for the changes, as well as where the information is and where to place it is the user's sole responsibility.
 
 ---
 
 ## 🚀 Features
 
-- Extracts **keymaster**, **gatekeeper**, **keymint** binaries and libraries from the given ROM dump directory.
-- Extracts binaries from `vendor/bin/hw` related to `keymaster`, `gatekeeper`, or `keymint`.
+- Extracts **keymaster**, **gatekeeper**, **keymint** binaries and libraries files from the Firmware folder.
+- Extracts binaries files from `vendor/bin/hw` related to `keymaster`, `gatekeeper`, or `keymint`.
+- Extracts binaries files from `vendor/bin` related to `mcRegistry`, `teei_daemon`, or `teed`.
 - Extracts files from the following paths if they exist:
   - `vendor/app/mcRegistry`
   - `vendor/thh/ta`
   - `vendor/mitee/ta`
+  - `vendor/app/t6`
 - Handles extraction for:
   - `system/lib64`
   - `system/lib64/hw`
+  - `system/etc`
+  - `system/etc/vintf`
+  - `system/etc/vintf/manifest`
   - `system_ext/lib64`
   - `system_ext/lib64/hw`
   - `vendor/lib64`
   - `vendor/lib64/hw`
   - `vendor/bin/hw`
+  - `vendor/bin`
+  - `vendor/firmware`
+  - `vendor/etc/vintf`
+  - `vendor/etc/vintf/manifest`
 - Cleans up **empty directories** after extraction, including automatically checking if `system_ext` is empty and deleting it.
 
 ---
@@ -30,52 +43,87 @@ This script is a utility for extracting specific system libraries, binaries, and
 Before using this script, ensure:
 
 1. **Bash Environment**: This script uses bash and is compatible with Linux and macOS systems with bash support.
-2. Ensure you have permission to access the ROM dump path provided.
-
-You will need to have a ROM dump (or extracted ROM system image) directory ready to use with this script.
+2. You will need to have a stock ROM files (or extracted stock ROM folders) ready to use with this script.
+3. Initially the script already has the appropriate permission to execute the extraction.
+    - In special cases aside, make sure you have permission to access the extracted folder, such as `extract_android_crypto_blobs` or another folder you want to create[^²].
 
 ---
 
 ## 💻 Installation
 
-1. Clone the repository:
+### Clone the repository:
    ```bash
    git clone https://github.com/GitFASTBOOT/extract_android_crypto_blobs.git
    cd extract_android_crypto_blobs
-   ```
-2. Ensure the script is executable:
-   ```bash
-   chmod +x extract_crypto_blobs.sh
    ```
 
 ---
 
 ## 🛠️ Usage
 
-### Extracting from a ROM dump
-1. Run the script with the path to your extracted ROM dump:
+### Unpacked stock ROM folders from firmware.img
+1. Copy stock ROM folders to `extract_android_crypto_blobs/Firmware` folder.
+   Example: `/Firmware/vendor` & `/Firmware/system` & `/Firmware/system_ext`
+   Dont't worries if you stock ROM not have `/system_ext`.
+   Usually the stock ROM system.img file is unpacked like this: `system/system/`. Note that we want the second part of `system` and therefore indicated like system/**system/**.
+
+   
+<details><summary>Click to open</summary>
+<p>
+
+## copy picture od FileManager extract_android_crypto_blobs/Firmware
+
+
+</p>
+</details>
+
+
+### Run the script
+2. Run[^³] the script according to the extracted extract_android_crypto_blobs folder or the folder that you created:
    ```bash
-   ./extract_crypto_blobs.sh "path/to/rom/dump"
+   ./extract_crypto_blobs.sh
    ```
 
-- Replace `"path/to/rom/dump"` with the actual path to your ROM dump directory.
+<details><summary>Click to open</summary>
+<p>
+
+## copy picture od FileManager extract_android_crypto_blobs
+
+
+</p>
+</details>
+
+
+[^¹]: If you want to learn more, visit [Copying firmware files to the Device Tree - Mediatek](https://gist.github.com/lopestom/c4a2648958db5c3db03d32033a3583cd)
+[^²]: This script **already has permission**. But if you have any doubts then you can check the script with:
+   ```bash
+   chmod +x extract_crypto_blobs.sh
+   ```
+
+[^³]: Use whatever Terminal emulator you want/prefer. You can type directly into the Terminal or double-click on the sh file.
 
 ---
 
 ## 📂 Directory Structure
 
-After extraction, the files will be sorted into the following directories:
+After extraction, the sorted files are automatically copied into the following appropriate directories:
 
 - **`./system/lib64/`**: System libraries extracted.
 - **`./system/lib64/hw/`**: Extracted hardware libraries.
+- **`./system/etc/vintf/manifest.xml`**: Extracted manifest file.
+- **`./system/etc/`**: Extracted event-log-tags & task_profiles.json files.
 - **`./system_ext/lib64/`**: System extension libraries extracted.
 - **`./system_ext/lib64/hw/`**: Extracted hardware system extension libraries.
 - **`./vendor/lib64/`**: Vendor libraries extracted.
 - **`./vendor/lib64/hw/`**: Extracted vendor hardware libraries.
-- **`./vendor/bin/hw/`**: Extracted `keymaster`, `gatekeeper`, `keymint`, and other relevant binaries.
+- **`./vendor/bin/hw/`**: Extracted `keymaster`, `gatekeeper`, `keymint`, and other relevant binaries files.
+- **`./vendor/bin/`**: Extracted `mcRegistry`, `teei_daemon`, `teed` or service, production-line, tee clients and ca files.
+- **`./vendor/firmware/`**: Vendor binaries extracted.
+- **`./vendor/etc/vintf/manifest.xml`**: Extracted manifest file.
 - **`./vendor/app/mcRegistry/`**: Extracted if it exists.
 - **`./vendor/thh/ta/`**: Extracted if it exists.
 - **`./vendor/mitee/ta/`**: Extracted if it exists.
+- **`./vendor/app/t6/`**: Extracted if it exists.
 
 ---
 
@@ -86,36 +134,53 @@ After extraction, the files will be sorted into the following directories:
    - Cleans `system_ext` only if it's completely empty.
 
 2. **Binaries Search**:
-   - The script searches for `keymaster`, `gatekeeper`, and `keymint` binaries/libraries automatically.
+   - The script searches for `keymaster`, `gatekeeper` and `keymint` binaries/libraries files automatically.
 
-3. **Support for Nested Extraction**:
-   - Ensures extraction from complex directory paths like `vendor/bin/hw/`, `vendor/thh/ta`, or other specialized subfolders.
+3. **Services Search**:
+   - The script searches for `beanpod`, `trustonic` and `trustkernel` services files automatically.
+     <details><summary>Click to open</summary>
+     <p>
+
+     ## copy pictureS od FileManager extract_android_crypto_blobs
+
+
+     </p>
+     </details>
+
+4. **Support for Nested Extraction**:
+   - Ensures extraction from complex directory paths like `vendor/bin/hw/`, `vendor/thh/ta`, `vendor/app/*.*` and/or other special subfolders.
 
 ---
 
-## 📝 Example Output
+## 📝 Example of Output script
 
-After running:
+Visualization and Explanation of script steps
+<details><summary>If you copied stock ROM to Firmware folder - Click to open</summary>
+<p>
 
-```bash
-./extract_crypto_blobs.sh "/path/to/rom/dump"
-```
+Step | happening |   | Step | happening
+| ---: | :--- | :---: | ---: | :---
+1-| Run the script |  | 6- | Debugging with encryption/decryption mode visualization
+2-| Alert message so you don't forget |  | 7- | Script starts searching to copy
+3-| Confirm your choice |  | 8- | Script searching and copying the files
+4-| Answer the question |  | 9- | Skipping the folders&files not finded
+5-| The script is starting |  | 10- | Script completion notice
 
-You might see output like:
 
-```
-Using ROM dump directory: /path/to/rom/dump
-Searching for libraries, binaries, mcRegistry, and thh/ta files in this path...
-Found: /path/to/rom/dump/system_ext/lib64/hw/libkeymaster.so
-Copying to system_ext/lib64/hw/
-Found: /path/to/rom/dump/vendor/bin/hw/gatekeeper
-Copying to vendor/bin/hw/
-Found vendor/app/mcRegistry directory. Extracting files...
-Found vendor/thh/ta directory. Extracting files...
-Cleaning up empty directories...
-Deleted empty system_ext directory.
-Extraction and cleanup completed.
-```
+</p>
+</details>
+
+
+<details><summary>If you **NOT** copied stock ROM to Firmware folder - Click to open</summary>
+<p>
+
+Step | happening |
+| ---: | :--- |
+11-| Simple message to continue script after required action
+
+
+</p>
+</details>
 
 ---
 

--- a/extract_crypto_blobs.sh
+++ b/extract_crypto_blobs.sh
@@ -1,31 +1,85 @@
 #!/bin/bash
 
+# Start .sh script
+#echo "Starting .sh script..."
+chmod u+x extract_crypto_blobs.sh
+
+# Create basic folder
+#echo " Creating Firmware folder"
+mkdir -p Firmware
+
+## This only stop scrypt if user not copy stock folders in path/
 # Check if a directory path is provided as an argument
-if [ "$#" -ne 1 ]; then
-    echo "Usage: $0 path/to/rom/dump"
-    exit 1
-fi
+#if [ "$#" -ne 1 ]; then
+#    echo "Usage: $0 /Firmware"
+#    exit 1
+#fi
+# Colors
+RED="\e[31m"
+GREEN="\e[32m"
+YELLOW="\e[33m"
+BLUE="\e[34m"
+MAGENTA="\e[35m"
+CYAN="\e[36m"
+RESET="\e[0m"  # Reset color
+
+echo " "
+#
+echo -e "${RED}        *************     BEFORE ANY ACTIONS     *************       "
+echo -e "************* COPY STOCK ROM FOLDERS TO Firmware FOLDER. *************"
+echo " "
+echo -e "${CYAN}###  Example: /Firmware/vendor & /Firmware/system & /Firmware/system_ext  ###${RESET}"
+echo " "
+#
+
+PS3="  Do you realy copied stock folders to Firmware folder?  "
+select word in "yes" "no"; do
+    echo "  The choice that you have selected is : $word  "
+    break
+done
+
+if [ "$word" = "yes" ];
+then
+clear
+
+  echo " Starting........  "
+sleep 2
 
 # Assign the provided argument to a variable
-ROM_DUMP_DIR="$1"
+ROM_DUMP_DIR="./Firmware"
 
 # Define destination directories
-DEST_SYSTEM_LIB64="./system/lib64"
-DEST_SYSTEM_LIB64_HW="./system/lib64/hw"
-DEST_SYSTEM_EXT_LIB64="./system_ext/lib64"
-DEST_SYSTEM_EXT_LIB64_HW="./system_ext/lib64/hw"
-DEST_VENDOR_LIB64="./vendor/lib64"
-DEST_VENDOR_LIB64_HW="./vendor/lib64/hw"
-DEST_VENDOR_BIN="./vendor/bin"
-DEST_VENDOR_BIN_HW="./vendor/bin/hw"
-DEST_VENDOR_APP_MCRegistry="./vendor/app/mcRegistry"
-DEST_VENDOR_THH="./vendor/thh"
-DEST_VENDOR_THH_TA="./vendor/thh/ta"
-DEST_VENDOR_MITEE_TA="./vendor/mitee/ta"
+s="system"
+v="vendor"
+l="lib64"
+DEST_SYSTEM_LIB64="./$s/$l"
+DEST_SYSTEM_LIB64_HW="./$s/$l/hw"
+DEST_SYSTEM_ETC_VINTF="./$s/etc/vintf"
+DEST_SYSTEM_ETC_MANIF="./$s/etc/vintf/manifest"
+DEST_SYSTEM_ETC="./$s/etc"
+DEST_SYSTEM_EXT_LIB64="./system_ext/$l"
+DEST_SYSTEM_EXT_LIB64_HW="./system_ext/$l/hw"
+DEST_VENDOR_LIB64="./$v/$l"
+DEST_VENDOR_LIB64_HW="./$v/$l/hw"
+DEST_VENDOR_BIN="./$v/bin"
+DEST_VENDOR_BIN_HW="./$v/bin/hw"
+DEST_VENDOR_APP_MCRegistry="./$v/app/mcRegistry"
+DEST_VENDOR_THH="./$v/thh"
+DEST_VENDOR_THH_TA="./$v/thh/ta"
+DEST_VENDOR_MITEE_TA="./$v/mitee/ta"
+DEST_VENDOR_APP="./$v/app"
+DEST_VENDOR_APP_t6="./$v/app/t6"
+DEST_VENDOR_FW="./$v/firmware"
+DEST_VENDOR_ETC="./$v/etc"
+DEST_VENDOR_ETC_VINTF="./$v/etc/vintf"
+DEST_VENDOR_ETC_MANIF="./$v/etc/vintf/manifest"
 
 # Create destination directories if they don't exist
 mkdir -p "$DEST_SYSTEM_LIB64"
 mkdir -p "$DEST_SYSTEM_LIB64_HW"
+mkdir -p "$DEST_SYSTEM_ETC_VINTF"
+mkdir -p "$DEST_SYSTEM_ETC_MANIF"
+mkdir -p "$DEST_SYSTEM_ETC"
 mkdir -p "$DEST_SYSTEM_EXT_LIB64"
 mkdir -p "$DEST_SYSTEM_EXT_LIB64_HW"
 mkdir -p "$DEST_VENDOR_LIB64"
@@ -35,32 +89,40 @@ mkdir -p "$DEST_VENDOR_BIN_HW"
 mkdir -p "$DEST_VENDOR_APP_MCRegistry"
 mkdir -p "$DEST_VENDOR_THH_TA"
 mkdir -p "$DEST_VENDOR_MITEE_TA"
+mkdir -p "$DEST_VENDOR_APP_t6"
+mkdir -p "$DEST_VENDOR_FW"
+mkdir -p "$DEST_VENDOR_ETC"
+mkdir -p "$DEST_VENDOR_ETC_VINTF"
+mkdir -p "$DEST_VENDOR_ETC_MANIF"
 
 # Debugging - log the ROM dump directory
 echo "Using ROM dump directory: $ROM_DUMP_DIR"
-echo "Searching for libraries, binaries, mcRegistry, thh/ta files, mcDriverDaemon, teei_daemon, and .rc files in this path..."
+echo "Searching for libraries, binaries, mcRegistry, thh/ta files, mcDriverDaemon, teei_daemon, teed, and .rc files in this path..."
 
 # Search for .rc files and copy them to the current directory
-find "$ROM_DUMP_DIR" -type f \( -name "microtrust.rc" -o -name "trustonic.rc" -o -name "tee.rc" \) | while read -r rc_file; do
+find "$ROM_DUMP_DIR" -type f \( -name "microtrust.rc" -o -name "trustonic.rc" -o -name "tee.rc" -o -name "trustkernel.rc" \) | while read -r rc_file; do
     echo "Found .rc file: $rc_file"
     echo "Copying to current directory"
     cp -v "$rc_file" ./
 
-    # Check if trustonic.rc is found and update init.custom.rc
-    if [[ "$rc_file" == *"trustonic.rc"* ]]; then
-        echo "trustonic.rc detected. Adding Trustonic mount instructions to init.custom.rc"
+    # Check if decrypt_file.rc is found and update init.custom.rc
+    if [[ "$rc_file" == **trust**.rc ]]; then
+        echo "decrypt_file.rc detected. Adding Trust mount instructions to init.custom.rc"
         INIT_CUSTOM_RC="./init.custom.rc"
         if [ ! -f "$INIT_CUSTOM_RC" ]; then
             touch "$INIT_CUSTOM_RC"
         fi
-        echo -e "\n#Added Manual For Trustonic" >> "$INIT_CUSTOM_RC"
+        echo -e "\non init" >> "$INIT_CUSTOM_RC"
+        echo "#Added Manual For Trustonic" >> "$INIT_CUSTOM_RC"
         echo "mkdir /mnt/vendor/persist" >> "$INIT_CUSTOM_RC"
         echo "mount ext4 /dev/block/by-name/persist /mnt/vendor/persist rw" >> "$INIT_CUSTOM_RC"
     fi
 done
 
-# Search for "keymaster", "gatekeeper", "keymint", "TEE", or "McClient" related .so files
-find "$ROM_DUMP_DIR" -type f \( -name "*keymaster*.so" -o -name "*gatekeeper*.so" -o -name "*keymint*.so" -o -name "*TEE*.so" -o -name "*McClient*.so" \) | while read -r file; do
+echo "Searching and Copying......."
+sleep 2
+# Search for "keymaster", "gatekeeper", "keymint", "tee", "TEE", "McClient" and others related .so files
+find "$ROM_DUMP_DIR" -type f \( -name "*keymaster*.so" -o -name "*gatekeeper*.so" -o -name "*keymint*.so" -o -name "*TEE*.so" -o -name "*McClient*.so" -o -name "*mtk_bsg*.so" -o -name "*kmsetkey*.so" -o -name "*imsg*.so" -o -name "*uree*.so" -o -name "*kph*.so" -o -name "libpl.so" -o -name "android.hidl.*.so" -o -name "libhidl*.so" -o -name "libion_*.so" -o -name "*Gatekeeper*.so" -o -name "*tee*.so" -o -name "libhwbinder.so" -o -name "libladder.so" \) | while read -r file; do
     echo "Found: $file"
     
     # Copy logic for system, system_ext, vendor directories
@@ -87,8 +149,8 @@ find "$ROM_DUMP_DIR" -type f \( -name "*keymaster*.so" -o -name "*gatekeeper*.so
     fi
 done
 
-# Search for binaries in vendor/bin/hw/ related to keymaster, gatekeeper, keymint, or teei_daemon
-find "$ROM_DUMP_DIR/vendor/bin/hw" -type f \( -name "*keymaster*" -o -name "*gatekeeper*" -o -name "*keymint*" -o -name "teei_daemon" \) | while read -r bin_file; do
+# Search for binaries in vendor/bin/hw/ related to keymaster, gatekeeper, keymint or trustonic.tee
+find "$ROM_DUMP_DIR/vendor/bin/hw" -type f \( -name "*keymaster*" -o -name "*gatekeeper*" -o -name "*keymint*" -o -name "*tee*" \) | while read -r bin_file; do
     echo "Found binary: $bin_file"
     
     # Copy logic for vendor/bin/hw
@@ -107,6 +169,109 @@ find "$ROM_DUMP_DIR/vendor/bin" -type f -name "mcDriverDaemon" | while read -r m
     cp -v "$mc_driver_file" "$DEST_VENDOR_BIN/"
 done
 
+# Search for teei_daemon in vendor/bin
+find "$ROM_DUMP_DIR/vendor/bin" -type f -name "teei_daemon" | while read -r teei_daemon_file; do
+    echo "Found teei_daemon $teei_daemon_file"
+    echo "Copying to vendor/bin/"
+    cp -v "$teei_daemon_file" "$DEST_VENDOR_BIN/"
+done
+
+# Search for teed in vendor/bin
+find "$ROM_DUMP_DIR/vendor/bin" -type f -name "teed" | while read -r teed_file; do
+    echo "Found teed $teed_file"
+    echo "Copying to vendor/bin/"
+    cp -v "$teed_file" "$DEST_VENDOR_BIN/"
+done
+
+# Search for kph in vendor/bin
+find "$ROM_DUMP_DIR/vendor/bin" -type f -name "kph" | while read -r kph_file; do
+    echo "Found kph $kph_file"
+    echo "Copying to vendor/bin/"
+    cp -v "$kph_file" "$DEST_VENDOR_BIN/"
+done
+
+# Search for pld in vendor/bin
+find "$ROM_DUMP_DIR/vendor/bin" -type f -name "pld" | while read -r pld_file; do
+    echo "Found pld $pld_file"
+    echo "Copying to vendor/bin/"
+    cp -v "$pld_file" "$DEST_VENDOR_BIN/"
+done
+
+# Search for tee_check_keybox in vendor/bin
+find "$ROM_DUMP_DIR/vendor/bin" -type f -name "tee_check_keybox" | while read -r keybox_file; do
+    echo "Found tee_check_keybox $keybox_file"
+    echo "Copying to vendor/bin/"
+    cp -v "$keybox_file" "$DEST_VENDOR_BIN/"
+done
+
+# Search for *-service.*.xml in system/etc/vintf/manifest
+find "$ROM_DUMP_DIR/system/etc/vintf/manifest" -type f -name "android.system.keystore2-service.xml" | while read -r smanif_file; do
+    echo "Found android.system.keystore2-service.xml $smanif_file"
+    echo "Copying to system/etc/vintf/manifest/"
+    cp -v "$smanif_file" "$DEST_SYSTEM_ETC_MANIF/"
+done
+
+# Search for manifest.xml & compatibility_matrix.*.xml and others in system/etc/vintf
+find "$ROM_DUMP_DIR/system/etc/vintf" -type f \( -name "manifest.xml" -o -name "compatibility_matrix.*.xml" \) | while read -r manif_file; do
+    echo "Found binary: $manif_file"
+    
+    # Copy logic for /system/etc/vintf/
+    if [[ "$manif_file" == *"/system/etc/vintf/"* ]]; then
+        echo "Copying to /system/etc/vintf/"
+        cp -v "$manif_file" "$DEST_SYSTEM_ETC_VINTF/"
+    else
+        echo "Unknown or unhandled files path for: $manif_file - skipping."
+    fi
+done
+
+# Search for event-log-tags & task_profiles.json in system/etc
+find "$ROM_DUMP_DIR/system/etc" -type f \( -name "event-log-tags" -o -name "task_profiles.json" \) | while read -r se_file; do
+    echo "Found binary: $se_file"
+    
+    # Copy logic for /system/etc
+    if [[ "$se_file" == *"/system/etc/"* ]]; then
+        echo "Copying to /system/etc/"
+        cp -v "$se_file" "$DEST_SYSTEM_ETC/"
+    else
+        echo "Unknown or unhandled files path for: $se_file - skipping."
+    fi
+done
+
+# Extract all files in vendor/firmware if it exists
+if [ -d "$ROM_DUMP_DIR/vendor/firmware" ]; then
+    echo "Found vendor/firmware directory. Extracting files..."
+    cp -r -v "$ROM_DUMP_DIR/vendor/firmware/." "$DEST_VENDOR_FW/"
+else
+    echo "No vendor/firmware directory found. Skipping."
+fi
+
+# Search for manifest.xml & compatibility_matrix.xml in vendor/etc/vintf
+find "$ROM_DUMP_DIR/vendor/etc/vintf" -type f \( -name "manifest.xml" -o -name "compatibility_matrix.xml" \) | while read -r vmanif_file; do
+    echo "Found binary: $vmanif_file"
+    
+    # Copy logic for vendor/etc/vintf/
+    if [[ "$vmanif_file" == *"vendor/etc/vintf/"* ]]; then
+        echo "Copying to vendor/etc/vintf/"
+        cp -v "$vmanif_file" "$DEST_VENDOR_ETC_VINTF/"
+    else
+        echo "Unknown or unhandled files path for: $vmanif_file - skipping."
+    fi
+done
+
+# Search for ueventd.rc in vendor/etc
+find "$ROM_DUMP_DIR/vendor/etc" -type f -name "ueventd.rc" | while read -r euev_file; do
+    echo "Found ueventd.rc $euev_file"
+    echo "Copying to vendor/etc/"
+    cp -v "$euev_file" "$DEST_VENDOR_ETC/"
+done
+
+# Search for *-service.*.xml in vendor/etc/vintf/manifest
+find "$ROM_DUMP_DIR/vendor/etc/vintf/manifest" -type f -name "*-service.*.xml" | while read -r manser_file; do
+    echo "Found all *-service.*.xml $manser_file"
+    echo "Copying to vendor/etc/vintf/manifest/"
+    cp -v "$manser_file" "$DEST_VENDOR_ETC_MANIF/"
+done
+
 # Extract all files in vendor/app/mcRegistry if it exists
 if [ -d "$ROM_DUMP_DIR/vendor/app/mcRegistry" ]; then
     echo "Found vendor/app/mcRegistry directory. Extracting files..."
@@ -121,6 +286,14 @@ if [ -d "$ROM_DUMP_DIR/vendor/thh/ta" ]; then
     cp -r -v "$ROM_DUMP_DIR/vendor/thh/ta/." "$DEST_VENDOR_THH_TA/"
 else
     echo "No vendor/thh/ta directory found. Skipping."
+fi
+
+# Extract all files in vendor/app/t6/ if it exists
+if [ -d "$ROM_DUMP_DIR/vendor/app/t6" ]; then
+    echo "Found vendor/app/t6 directory. Extracting files..."
+    cp -r -v "$ROM_DUMP_DIR/vendor/app/t6/." "$DEST_VENDOR_APP_t6/"
+else
+    echo "No vendor/app/t6 directory found. Skipping."
 fi
 
 # Extract all files in vendor/mitee/ta if it exists
@@ -191,6 +364,10 @@ else
     echo "No vendor/mitee folder detected. Skipping init.mitee.rc creation."
 fi
 
+sleep 3
+
+clear
+
 # Function to delete empty directories
 delete_empty_dirs() {
     local dir="$1"
@@ -210,6 +387,7 @@ delete_empty_dirs "$DEST_VENDOR_BIN"
 delete_empty_dirs "$DEST_VENDOR_APP_MCRegistry"
 delete_empty_dirs "$DEST_VENDOR_THH_TA"
 delete_empty_dirs "$DEST_VENDOR_MITEE_TA"
+delete_empty_dirs "$DEST_VENDOR_APP"
 
 # Special cleanup for vendor/thh if it's empty
 if [ -d "$DEST_VENDOR_THH" ]; then
@@ -220,6 +398,17 @@ if [ -d "$DEST_VENDOR_THH" ]; then
         echo "Deleted empty vendor/thh directory."
     else
         echo "vendor/thh is not empty. Skipping deletion."
+    fi
+fi
+
+if [ -d "$DEST_VENDOR_APP" ]; then
+    echo "Checking if vendor/app is empty..."
+    if [ -z "$(ls -A "$DEST_VENDOR_APP")" ]; then
+        echo "vendor/app is empty. Deleting it..."
+        rm -rf "$DEST_VENDOR_APP"
+        echo "Deleted empty vendor/app directory."
+    else
+        echo "vendor/app is not empty. Skipping deletion."
     fi
 fi
 
@@ -247,6 +436,18 @@ if [ -d "./vendor/mitee" ]; then
     fi
 fi
 
-# Final Debugging Log
-echo "Extraction and cleanup completed."
 
+else [ "$word" = "no" ];
+
+  echo " Provide a stock forlders and continue after that. "  
+
+exit 0
+
+fi
+
+clear
+
+# Final Debugging Log
+echo -e "${GREEN}===   Extraction and cleanup completed.   ===${RESET}"
+
+sleep 2


### PR DESCRIPTION
- Included the necessary permission: `chmod u+x extract_crypto_blobs.sh`
- Changed how the path should be placed so that the user can copy and paste the stock ROM folders into the indicated folder. This provides more security so that no one loses the stock ROM folders and their files, as well as wasting time and any user pointing out that the script deleted them: `mkdir -p Firmware`; `ROM_DUMP_DIR="./Firmware"`
- Added warnings (alerts and information) and colors in that
- Added a choice based on what the user really wants and what he has so that the script does not have errors/forgetfulness coming exactly from the user himself
- Modified the action with `rc_file` so that all encryption modes contain the init.custom.rc file in the output
- Defined other destination directories to extract files in system/etc, system/etc/vintf, system/etc/vintf/manifest
- Defined other destination directories to extract files in vendor/app/t6, vendor/bin, vendor/firmware, vendor/etc/vintf, vendor/etc/vintf/manifest
- Defined more variables based on new folders for extraction
- Included trustkernel mode
- Added more actions for file extraction for trustonic, beanpod and trustkernel mode
- Changed the Readme.md file with more information, warnings, pictures and instructions about the script